### PR TITLE
Improvements on README table algorithm links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # algorithms hacktoberfest2021
 
-Make some algorithms in differents languages, about the issues.
-How it's work ?
+Make some algorithms in differents languages, about the issues. How it's work ?
 
 - Create some issues for one algorithm.
 - Fork the repos, make it and create a Pull Request
@@ -50,7 +49,7 @@ How it's work ?
   <tbody>
     <!-- Minimun in array -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-min">Minimum in array</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-min">Minimum in array</a></td>
       <td><code>ar-min</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -64,7 +63,7 @@ How it's work ?
     </tr>
     <!-- Bin sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-binsrt">Bin Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-binsrt">Bin Sort</a></td>
       <td><code>ar-binsrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -78,7 +77,7 @@ How it's work ?
     </tr>
     <!-- Binary search algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/gr-bfsrh">Breadth First Search</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/gr-bfsrh">Breadth First Search</a></td>
       <td><code>gr-bfsrh</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -92,7 +91,7 @@ How it's work ?
     </tr>
     <!-- Bubble sort algorithm -->
     <tr>
-      <td> <a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-bsrt">Bubble Sort</a></td>
+      <td> <a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-bsrt">Bubble Sort</a></td>
       <td><code>ar-bsrt</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -106,7 +105,7 @@ How it's work ?
     </tr>
     <!-- Coin change problem algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-cochprb">Coin Change Problem</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-cochprb">Coin Change Problem</a></td>
       <td><code>ar-cochprb</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -120,7 +119,7 @@ How it's work ?
     </tr>
     <!-- Depth first search algorithm -->
     <tr>
-      <td> <a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/gr-dfsrh">Depth First Search</a></td>
+      <td> <a href="./algorithmshacktoberfest2021/tree/main/algorithms/gr-dfsrh">Depth First Search</a></td>
       <td><code>gr-dfsrh</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -134,7 +133,7 @@ How it's work ?
     </tr>
     <!-- Dijkstra algorithm -->
     <tr>
-      <td> <a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/gr-dij">Dijkstra Algorithm</a></td>
+      <td> <a href="./algorithmshacktoberfest2021/tree/main/algorithms/gr-dij">Dijkstra Algorithm</a></td>
       <td><code>gr-dij</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -148,7 +147,7 @@ How it's work ?
     </tr>
     <!-- Exponentiation by squaring algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-expsq">Exponentiation by Squaring</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-expsq">Exponentiation by Squaring</a></td>
       <td><code>ar-expsq</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -162,7 +161,7 @@ How it's work ?
     </tr>
     <!-- Heap sort algorithm -->
     <tr>
-      <td> <a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-hsrt">Heap Sort</a></td>
+      <td> <a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-hsrt">Heap Sort</a></td>
       <td><code>ar-hsrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -176,7 +175,7 @@ How it's work ?
     </tr>
     <!-- Insertion sort algorithm -->
     <tr>
-      <td> <a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-isrt">Insertion Sort</a></td>
+      <td> <a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-isrt">Insertion Sort</a></td>
       <td><code>ar-isrt</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -190,7 +189,7 @@ How it's work ?
     </tr>
      <!-- Kadane's Algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-kdn">Kadane's Algorithm</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-kdn">Kadane's Algorithm</a></td>
       <td><code>ar-kdn</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -204,7 +203,7 @@ How it's work ?
     </tr>
     <!-- KMP algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-kmp">Knuth-Morris-Pratt</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-kmp">Knuth-Morris-Pratt</a></td>
       <td><code>ar-kmp</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -218,7 +217,7 @@ How it's work ?
     </tr>
     <!-- K-NN algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-knn">K-NN</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-knn">K-NN</a></td>
       <td><code>ar-knn</code></td>
       <td class="text-center"></td>
       <td class="text-center"></td>
@@ -232,7 +231,7 @@ How it's work ?
     </tr>
     <!-- Largest sum contiguous sub-array algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-lscsa">Largest Sum Contiguous Sub-Array</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lscsa">Largest Sum Contiguous Sub-Array</a></td>
       <td><code>ar-lscsa</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -246,7 +245,7 @@ How it's work ?
     </tr>
     <!-- Linear regression algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-lsrh">Linear Search</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lsrh">Linear Search</a></td>
       <td><code>ar-lsrh</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -260,7 +259,7 @@ How it's work ?
     </tr>
     <!-- Longest common subsequence algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-lcs">Longest Common Subsequence</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lcs">Longest Common Subsequence</a></td>
       <td><code>ar-lcs</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -274,7 +273,7 @@ How it's work ?
     </tr>
     <!-- Longest increasing subsequence algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-lis">Longest Increasing Subsequence</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lis">Longest Increasing Subsequence</a></td>
       <td><code>ar-lis</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -288,7 +287,7 @@ How it's work ?
     </tr>
     <!-- Longest palindromic substring algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-lps">Longest Palindromic Substring</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lps">Longest Palindromic Substring</a></td>
       <td><code>ar-lps</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -302,7 +301,7 @@ How it's work ?
     </tr>
     <!-- Merge sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-msrt">Merge Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-msrt">Merge Sort</a></td>
       <td><code>ar-msrt</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -316,7 +315,7 @@ How it's work ?
     </tr>
     <!-- Modular exponential algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-mexp">Modular Exponential</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-mexp">Modular Exponential</a></td>
       <td><code>ar-mexp</code></td>
       <td class="text-center"></td>
       <td class="text-center"></td>
@@ -330,7 +329,7 @@ How it's work ?
     </tr>
     <!-- Naive search algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-nsrh">Naive Search</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-nsrh">Naive Search</a></td>
       <td><code>ar-nsrh</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -344,7 +343,7 @@ How it's work ?
     </tr>
     <!-- Pigeonhole Sort algorithm -->
      <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-nsrh">Naive Search</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-nsrh">Naive Search</a></td>
       <td><code>ar-nsrh</code></td>
       <td class="text-center">Done</td>
       <td class="text-center"></td>
@@ -358,7 +357,7 @@ How it's work ?
     </tr>
     <!-- Prime factor algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-prfac">Prime Factor</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-prfac">Prime Factor</a></td>
       <td><code>ar-prfac</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -372,7 +371,7 @@ How it's work ?
     </tr>
     <!-- Prims algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/gr-prims">Prims</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/gr-prims">Prims</a></td>
       <td><code>gr-prims</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -386,7 +385,7 @@ How it's work ?
     </tr>
     <!-- Quick select algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-qsel">Quick Select</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-qsel">Quick Select</a></td>
       <td><code>ar-qsel</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -400,7 +399,7 @@ How it's work ?
     </tr>
     <!-- Quick sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-qsrt">Quick Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-qsrt">Quick Sort</a></td>
       <td><code>ar-qsrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -414,7 +413,7 @@ How it's work ?
     </tr>
     <!-- Radix sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-radsrt">Radix Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-radsrt">Radix Sort</a></td>
       <td><code>ar-radsrt</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -428,7 +427,7 @@ How it's work ?
     </tr>
     <!-- Rod cutting problem -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-rcprb">Rod Cutting Problem</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-rcprb">Rod Cutting Problem</a></td>
       <td><code>ar-rcprb</code></td>
       <td class="text-center"></td>
       <td class="text-center"></td>
@@ -442,7 +441,7 @@ How it's work ?
     </tr>
     <!-- Selection sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-ssrt">Selection Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-ssrt">Selection Sort</a></td>
       <td><code>ar-ssrt</code></td>
       <td class="text-center">Done</td>
       <td class="text-center">Done</td>
@@ -456,7 +455,7 @@ How it's work ?
     </tr>
     <!-- Shell sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-shsrt">Shell Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-shsrt">Shell Sort</a></td>
       <td><code>ar-shsrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -470,7 +469,7 @@ How it's work ?
     </tr>
     <!-- Sieve of eratosthenes algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-soer">Sieve of Erastosthenes</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-soer">Sieve of Erastosthenes</a></td>
       <td><code>ar-soer</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -484,7 +483,7 @@ How it's work ?
     </tr>
     <!-- Sleep sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-slpsrt">Sleep Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-slpsrt">Sleep Sort</a></td>
       <td><code>ar-slpsrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -498,7 +497,7 @@ How it's work ?
     </tr>
         <!-- Spiral Matrix -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2020/tree/main/algorithms/ar-spmat">Spiral Matrix</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-spmat">Spiral Matrix</a></td>
       <td><code>ar-spmat</code></td>
       <td class="text-center"></td>
       <td class="text-center"></td>
@@ -512,7 +511,7 @@ How it's work ?
     </tr>
      <!-- Count sort algorithm -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-csrt">Count Sort</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-csrt">Count Sort</a></td>
       <td><code>ar-csrt</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -526,7 +525,7 @@ How it's work ?
     </tr>
     <!-- Z function -->
     <tr>
-     <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/blob/main/algorithms/z_function.cpp">Z function</a></td>
+     <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-zfnc">Z function</a></td>
       <td><code>ar-zfnc</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -540,7 +539,7 @@ How it's work ?
     </tr>
     <!-- Red blacktree -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/blob/main/algorithms/Red-blacktree-Algorithm/">Red Blacktree</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-rbtree">Red Blacktree</a></td>
       <td><code>ar-rbtree</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -554,7 +553,7 @@ How it's work ?
     </tr>
     <!-- Rock Paper Scissor -->
     <tr>
-      <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/blob/main/algorithms/Rrock_paper_scissor/">Rock Paper Scissor</a></td>
+      <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-rpprscs">Rock Paper Scissor</a></td>
       <td><code>ar-rpprscs</code></td>
       <td class="text-center">Done</td>
       <td class="text-center"></td>
@@ -568,7 +567,7 @@ How it's work ?
     </tr>
     <!-- String Hashing Algorithm -->
     <tr>
-     <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/blob/main/algorithms/hashing.cpp">String Hashing</a></td>
+     <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-strhsg">String Hashing</a></td>
       <td><code>ar-strhsg</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -582,7 +581,7 @@ How it's work ?
     </tr>
     <!-- Left View of binary tree -->
     <tr>
-     <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/blob/main/algorithms/hashing.cpp">Left View Binary Tree</a></td>
+     <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-lvwbintr">Left View Binary Tree</a></td>
       <td><code>ar-lvwbintr</code></td>
       <td class="text-center"></td>
       <td class="text-center">Done</td>
@@ -596,7 +595,7 @@ How it's work ?
     </tr>
     <!-- Top View of binary tree -->
     <tr>
-     <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-tvwbintr">Top View Binary Tree</a></td>
+     <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-tvwbintr">Top View Binary Tree</a></td>
       <td><code>ar-tvwbintr</code></td>
       <td class="text-center"></td>
       <td class="text-center">done</td>
@@ -610,7 +609,7 @@ How it's work ?
     </tr>
     <!-- Bottom View of binary tree -->
     <tr>
-     <td><a href="https://github.com/Knackie/algorithmshacktoberfest2021/tree/main/algorithms/ar-bvwbintr">Bottom View Binary Tree</a></td>
+     <td><a href="./algorithmshacktoberfest2021/tree/main/algorithms/ar-bvwbintr">Bottom View Binary Tree</a></td>
       <td><code>ar-bvwbintr</code></td>
       <td class="text-center"></td>
       <td class="text-center"></td>


### PR DESCRIPTION
Conversion of table links into relative links to ensure fork consistency.

This commit also fixes these broken algorithm links:

- Z function (ar-zfnc)
- Red blacktree (ar-rbtree)
- Rock Paper Scissor (ar-rpprscs)
- String Hashing Algorithm (ar-strhsg)
- Left View Binary Tree (ar-lvwbintr)

Ref: #176